### PR TITLE
Refactor PGN utilities into shared module

### DIFF
--- a/index.html
+++ b/index.html
@@ -990,6 +990,12 @@
     import {
       runAnalysis as runPreparationAnalysis,
     } from './src/analysis/preparation-service.js';
+    import {
+      canonicalizeOpeningTokens,
+      loadPgnCompat,
+      normalizeToTokens,
+      sanitizeSanSequence,
+    } from './src/utils/pgn.js';
 
     // ------------ ECO MAP DE BASE + PACK XL ------------
     const ECO_OPENINGS = new Map([
@@ -1279,126 +1285,6 @@
       const t = setTimeout(() => ctrl.abort(), ms);
       const cleanup = () => clearTimeout(t);
       return { signal: ctrl.signal, cleanup };
-    }
-
-    // ------------ PGN → TOKENS ------------
-    function loadPgnCompat(chessInstance, pgn, options) {
-      const loader = typeof chessInstance.loadPgn === 'function'
-        ? chessInstance.loadPgn
-        : typeof chessInstance.load_pgn === 'function'
-          ? chessInstance.load_pgn
-          : null;
-      if (!loader) throw new Error('No loadPgn function available on chess.js instance');
-      return loader.call(chessInstance, pgn, options);
-    }
-
-    const DEFAULT_START_FEN = new Chess().fen();
-    const BLACK_START_FEN = DEFAULT_START_FEN.replace(' w ', ' b ');
-
-    function normalizeToTokens(pgn) {
-      if (!pgn || typeof pgn !== 'string') return [];
-
-      const trimmed = pgn.trim();
-      const startsWithBlack =
-        /^\s*\d+\s*\.\.\./.test(trimmed) ||
-        /^\s*\.\.\./.test(trimmed);
-      const initialTurn = startsWithBlack ? 'black' : 'white';
-
-      try {
-        const chess = new Chess();
-        const loaded = loadPgnCompat(chess, pgn, { sloppy: true });
-        if (loaded) {
-          const history = chess
-            .history({ verbose: true })
-            .map(move => move?.san || '')
-            .filter(Boolean);
-          return canonicalizeOpeningTokens(history, 'white');
-        }
-      } catch (err) {
-        console.warn('Failed to parse PGN via chess.js', err);
-      }
-
-      let s = pgn
-        .replace(/\{[^}]*\}/g, ' ')
-        .replace(/;.*/g, ' ')
-        .replace(/\([^)]*\)/g, ' ')
-        .replace(/\$\d+/g, ' ');
-
-      s = s.replace(/\b(1-0|0-1|1\/2-1\/2|\*)\b/g, ' ');
-      s = s.replace(/\d+\.(\.\.)?/g, ' ');
-      s = s.replace(/[+#]/g, '');
-      s = s.replace(/\s+/g, ' ').trim();
-
-      if (!s) return [];
-
-      const tokens = s
-        .split(' ')
-        .filter(tok =>
-          /^[O0]-O(-O)?$/.test(tok) ||
-          /^[KQRNB]?[a-h]?[1-8]?x?[a-h][1-8](=[QRNB])?$/.test(tok) ||
-          /^[a-h]x?[a-h][1-8](=[QRNB])?$/.test(tok) ||
-          /^[a-h][1-8]$/.test(tok) ||
-          /^[KQRNB][a-h][1-8]$/.test(tok)
-        )
-        .map(tok => tok.replace(/^0-0$/, 'O-O').replace(/^0-0-0$/, 'O-O-O'));
-
-      return canonicalizeOpeningTokens(tokens, initialTurn);
-    }
-
-    function sanitizeSanSequence(seq = []) {
-      return (seq || []).map((san) =>
-        String(san || '')
-          .trim()
-          .replace(/[+#?!]/g, '')
-      );
-    }
-
-    function canonicalizeOpeningTokens(tokens = [], startTurn = 'white', triedBlackFallback = false) {
-      const sanitized = sanitizeSanSequence(tokens);
-      const chess = new Chess();
-      if (startTurn === 'black') {
-        if (!chess.load(BLACK_START_FEN)) {
-          chess.reset();
-        }
-      }
-      const cleaned = [];
-      let warned = false;
-      let sawLeadingInvalid = false;
-      for (const san of sanitized) {
-        if (!san) continue;
-        let played;
-        try {
-          played = chess.move(san, { sloppy: true });
-        } catch (err) {
-          if (!cleaned.length) {
-            sawLeadingInvalid = true;
-            continue;
-          }
-          if (!warned) {
-            console.warn('Unable to apply SAN token', san, err);
-            warned = true;
-          }
-          break;
-        }
-        if (!played) {
-          if (!cleaned.length) {
-            sawLeadingInvalid = true;
-            continue;
-          }
-          if (!warned) {
-            console.warn('Unable to apply SAN token', san);
-            warned = true;
-          }
-          break;
-        }
-        const canonical = String(played.san || san).replace(/[+#?!]/g, '');
-        cleaned.push(canonical);
-      }
-      if (!cleaned.length && startTurn === 'white' && sawLeadingInvalid && !triedBlackFallback) {
-        // Certains PGN tronqués commencent directement par un coup noir ("1... e5").
-        return canonicalizeOpeningTokens(sanitized, 'black', true);
-      }
-      return cleaned;
     }
 
     // ------------ MATCHING OUVERTURE ------------

--- a/lichess-explorer.js
+++ b/lichess-explorer.js
@@ -1,18 +1,9 @@
 // lichess-explorer.js — outils Explorer & Masters
 // npm i chess.js  (ou <script type="module" src="https://cdn.jsdelivr.net/npm/chess.js@1/dist/chess.min.js">)
 import { Chess } from "https://esm.sh/chess.js";
+import { loadPgnCompat, sanitizeSanSequence } from "./src/utils/pgn.js";
 
-export function loadPgnCompat(chessInstance, pgn, options) {
-  const loader = typeof chessInstance.loadPgn === "function"
-    ? chessInstance.loadPgn
-    : typeof chessInstance.load_pgn === "function"
-      ? chessInstance.load_pgn
-      : null;
-  if (!loader) {
-    throw new Error("No loadPgn function available on chess.js instance");
-  }
-  return loader.call(chessInstance, pgn, options);
-}
+export { loadPgnCompat, sanitizeSanSequence };
 
 const BASE = "https://explorer.lichess.ovh/lichess";
 const MASTER_BASE = "https://explorer.lichess.ovh/master";
@@ -67,14 +58,6 @@ export function pgnToFenAndUci(pgn, limitPlies = 20) {
     .history({ verbose: true })
     .map((m) => m.from + m.to + (m.promotion || ""));
   return { fen, uciMoves, plies: uciMoves.length };
-}
-
-export function sanitizeSanSequence(seq = []) {
-  return (seq || []).map((san) =>
-    String(san || "")
-      .trim()
-      .replace(/[+#?!]/g, "")
-  );
 }
 
 function buildUrlFen({

--- a/src/utils/pgn.js
+++ b/src/utils/pgn.js
@@ -1,0 +1,119 @@
+import { Chess } from 'https://esm.sh/chess.js';
+
+export function loadPgnCompat(chessInstance, pgn, options) {
+  const loader = typeof chessInstance.loadPgn === 'function'
+    ? chessInstance.loadPgn
+    : typeof chessInstance.load_pgn === 'function'
+      ? chessInstance.load_pgn
+      : null;
+  if (!loader) throw new Error('No loadPgn function available on chess.js instance');
+  return loader.call(chessInstance, pgn, options);
+}
+
+const DEFAULT_START_FEN = new Chess().fen();
+const BLACK_START_FEN = DEFAULT_START_FEN.replace(' w ', ' b ');
+
+export function sanitizeSanSequence(seq = []) {
+  return (seq || []).map((san) =>
+    String(san || '')
+      .trim()
+      .replace(/[+#?!]/g, '')
+  );
+}
+
+export function canonicalizeOpeningTokens(tokens = [], startTurn = 'white', triedBlackFallback = false) {
+  const sanitized = sanitizeSanSequence(tokens);
+  const chess = new Chess();
+  if (startTurn === 'black') {
+    if (!chess.load(BLACK_START_FEN)) {
+      chess.reset();
+    }
+  }
+  const cleaned = [];
+  let warned = false;
+  let sawLeadingInvalid = false;
+  for (const san of sanitized) {
+    if (!san) continue;
+    let played;
+    try {
+      played = chess.move(san, { sloppy: true });
+    } catch (err) {
+      if (!cleaned.length) {
+        sawLeadingInvalid = true;
+        continue;
+      }
+      if (!warned) {
+        console.warn('Unable to apply SAN token', san, err);
+        warned = true;
+      }
+      break;
+    }
+    if (!played) {
+      if (!cleaned.length) {
+        sawLeadingInvalid = true;
+        continue;
+      }
+      if (!warned) {
+        console.warn('Unable to apply SAN token', san);
+        warned = true;
+      }
+      break;
+    }
+    const canonical = String(played.san || san).replace(/[+#?!]/g, '');
+    cleaned.push(canonical);
+  }
+  if (!cleaned.length && startTurn === 'white' && sawLeadingInvalid && !triedBlackFallback) {
+    return canonicalizeOpeningTokens(sanitized, 'black', true);
+  }
+  return cleaned;
+}
+
+export function normalizeToTokens(pgn) {
+  if (!pgn || typeof pgn !== 'string') return [];
+
+  const trimmed = pgn.trim();
+  const startsWithBlack =
+    /^\s*\d+\s*\.\.\./.test(trimmed) ||
+    /^\s*\.\.\./.test(trimmed);
+  const initialTurn = startsWithBlack ? 'black' : 'white';
+
+  try {
+    const chess = new Chess();
+    const loaded = loadPgnCompat(chess, pgn, { sloppy: true });
+    if (loaded) {
+      const history = chess
+        .history({ verbose: true })
+        .map(move => move?.san || '')
+        .filter(Boolean);
+      return canonicalizeOpeningTokens(history, 'white');
+    }
+  } catch (err) {
+    console.warn('Failed to parse PGN via chess.js', err);
+  }
+
+  let s = pgn
+    .replace(/\{[^}]*\}/g, ' ')
+    .replace(/;.*/g, ' ')
+    .replace(/\([^)]*\)/g, ' ')
+    .replace(/\$\d+/g, ' ');
+
+  s = s.replace(/\b(1-0|0-1|1\/2-1\/2|\*)\b/g, ' ');
+  s = s.replace(/\d+\.(\.\.)?/g, ' ');
+  s = s.replace(/[+#]/g, ' ');
+  s = s.replace(/\s+/g, ' ').trim();
+
+  if (!s) return [];
+
+  const tokens = s
+    .split(' ')
+    .filter(tok =>
+      /^[O0]-O(-O)?$/.test(tok) ||
+      /^[KQRNB]?[a-h]?[1-8]?x?[a-h][1-8](=[QRNB])?$/.test(tok) ||
+      /^[a-h]x?[a-h][1-8](=[QRNB])?$/.test(tok) ||
+      /^[a-h][1-8]$/.test(tok) ||
+      /^[KQRNB][a-h][1-8]$/.test(tok)
+    )
+    .map(tok => tok.replace(/^0-0$/, 'O-O').replace(/^0-0-0$/, 'O-O-O'));
+
+  return canonicalizeOpeningTokens(tokens, initialTurn);
+}

--- a/trap-engine.js
+++ b/trap-engine.js
@@ -1,32 +1,7 @@
 // trap-engine.js
 // Moteur de détection de pièges : trie SAN + recos par famille d’ouverture.
 
-function normalizeToTokens(pgn) {
-  if (!pgn || typeof pgn !== "string") return [];
-  let s = pgn
-    .replace(/\{[^}]*\}/g, " ")
-    .replace(/;.*/g, " ")
-    .replace(/\([^)]*\)/g, " ")
-    .replace(/\$\d+/g, " ")
-    .replace(/\b(1-0|0-1|1\/2-1\/2|\*)\b/g, " ")
-    .replace(/\d+\.(\.\.)?/g, " ")
-    .replace(/x/g, "")
-    .replace(/[+#]/g, "")
-    .replace(/=([QRNB])\b/g, "")
-    .replace(/\s+/g, " ")
-    .trim();
-  if (!s) return [];
-  return s
-    .split(" ")
-    .map((tok) => (tok === "0-0" ? "O-O" : tok === "0-0-0" ? "O-O-O" : tok))
-    .filter(
-      (tok) =>
-        /^O-O(-O)?$/.test(tok) ||
-        /^[KQRNB]?[a-h]?[1-8]?[a-h][1-8]$/.test(tok) ||
-        /^[a-h][1-8]$/.test(tok) ||
-        /^[KQRNB][a-h][1-8]$/.test(tok)
-    );
-}
+import { normalizeToTokens } from "./src/utils/pgn.js";
 
 // Petit util pour savoir le camp au demi-coup i (0 = trait aux Blancs)
 const sideAtPly = (startPly) => (startPly % 2 === 0 ? "white" : "black");


### PR DESCRIPTION
## Summary
- extract PGN parsing helpers into a reusable `src/utils/pgn.js` module
- update browser entrypoints to import the shared PGN helpers and drop duplicate logic

## Testing
- browser_container.run_playwright_script manual PGN load check

------
https://chatgpt.com/codex/tasks/task_e_68d9152d22ac8327a11473623b27c5ce