### PR TITLE
Add explorer client caching and gating controls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -158,6 +158,66 @@ export default function App() {
             </label>
             <input type="number" id="minMasterGames" min={10} max={500} step={10} defaultValue={50} />
           </div>
+          <div className="control-field">
+            <label className="control-label" htmlFor="explorerTtlHours">
+              TTL cache Explorer (h)
+              <span
+                className="info-bubble"
+                tabIndex={0}
+                role="tooltip"
+                aria-label="Durée de conservation des réponses Explorer en cache (en heures)."
+                data-tooltip="Durée de conservation des réponses Explorer en cache (en heures)."
+              >
+                ?
+              </span>
+            </label>
+            <input type="number" id="explorerTtlHours" min={1} max={168} step={1} defaultValue={24} />
+          </div>
+          <div className="control-field">
+            <label className="control-label" htmlFor="minExplorerCount">
+              Volume mini par ouverture
+              <span
+                className="info-bubble"
+                tabIndex={0}
+                role="tooltip"
+                aria-label="Nombre minimal de parties avant de solliciter Lichess Explorer."
+                data-tooltip="Nombre minimal de parties avant de solliciter Lichess Explorer."
+              >
+                ?
+              </span>
+            </label>
+            <input type="number" id="minExplorerCount" min={1} max={20} step={1} defaultValue={3} />
+          </div>
+          <div className="control-field">
+            <label className="control-label" htmlFor="maxExplorerPerSide">
+              Max ouvertures par couleur
+              <span
+                className="info-bubble"
+                tabIndex={0}
+                role="tooltip"
+                aria-label="Nombre maximal d'ouvertures analysées par couleur via Lichess Explorer."
+                data-tooltip="Nombre maximal d'ouvertures analysées par couleur via Lichess Explorer."
+              >
+                ?
+              </span>
+            </label>
+            <input type="number" id="maxExplorerPerSide" min={1} max={12} step={1} defaultValue={6} />
+          </div>
+          <div className="control-field">
+            <label className="control-label" htmlFor="strictExplorerMode">
+              Mode strict Explorer
+              <span
+                className="info-bubble"
+                tabIndex={0}
+                role="tooltip"
+                aria-label="En mode strict, toute indisponibilité Explorer stoppe l'enrichissement et propose de réessayer plus tard."
+                data-tooltip="En mode strict, toute indisponibilité Explorer stoppe l'enrichissement et propose de réessayer plus tard."
+              >
+                ?
+              </span>
+            </label>
+            <input type="checkbox" id="strictExplorerMode" defaultChecked />
+          </div>
           <button id="analyzeBtn" className="primary-action">
             Lancer l&apos;analyse
           </button>

--- a/src/advise-cached.js
+++ b/src/advise-cached.js
@@ -1,0 +1,25 @@
+// Cache léger en mémoire pour les recommandations Lichess afin d'éviter
+// les requêtes redondantes durant une session d'analyse.
+import { adviseFromLichess } from '../lichess-explorer.js';
+
+const adviseMem = new Map();
+const ADVISE_TTL_MS = 1000 * 60 * 60 * 24;
+
+function keyForAdvise({ tokens, sideToMove, playerRating, ratingOffset, speed, top }) {
+  return JSON.stringify({ tokens, sideToMove, playerRating, ratingOffset, speed, top });
+}
+
+export async function adviseCached(params) {
+  const key = keyForAdvise(params || {});
+  const existing = adviseMem.get(key);
+  if (existing && Date.now() - existing.t < ADVISE_TTL_MS) {
+    return existing.v;
+  }
+  const value = await adviseFromLichess(params);
+  adviseMem.set(key, { t: Date.now(), v: value });
+  return value;
+}
+
+export function clearAdviseCache() {
+  adviseMem.clear();
+}

--- a/src/explorer-client.js
+++ b/src/explorer-client.js
@@ -1,0 +1,208 @@
+// Client unifié pour interagir avec Lichess Explorer en appliquant cache multi-niveaux,
+// déduplication et régulation du débit.
+import { fetchExplorer } from '../lichess-explorer.js';
+
+const DEFAULT_EXPLORER_TTL_MS = 1000 * 60 * 60 * 24; // 24h
+const DEFAULT_MAX_CACHE_ITEMS = 1000;
+const DEFAULT_RATE_LIMIT = { rate: 15, per: 60_000, burst: 5 };
+
+let explorerTtlMs = DEFAULT_EXPLORER_TTL_MS;
+let maxCacheItems = DEFAULT_MAX_CACHE_ITEMS;
+let rateLimitConfig = { ...DEFAULT_RATE_LIMIT };
+
+const mem = new Map(); // key -> { t:number, v:any }
+function memGet(k) {
+  const it = mem.get(k);
+  if (!it) return null;
+  if (Date.now() - it.t > explorerTtlMs) {
+    mem.delete(k);
+    return null;
+  }
+  mem.delete(k);
+  mem.set(k, it);
+  return it.v;
+}
+function memSet(k, v) {
+  if (mem.size >= maxCacheItems) {
+    const first = mem.keys().next().value;
+    if (first) mem.delete(first);
+  }
+  mem.set(k, { t: Date.now(), v });
+}
+
+const IDB_KEY = 'explorer-cache-v1';
+function idbAvailable() {
+  try {
+    return typeof indexedDB !== 'undefined';
+  } catch {
+    return false;
+  }
+}
+let idbPromise = null;
+function openDb() {
+  if (!idbAvailable()) return null;
+  if (idbPromise) return idbPromise;
+  idbPromise = new Promise((resolve, reject) => {
+    const req = indexedDB.open(IDB_KEY, 1);
+    req.onupgradeneeded = () => {
+      req.result.createObjectStore('kv');
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+  return idbPromise;
+}
+async function idbGet(k) {
+  try {
+    const db = await openDb();
+    if (!db) return null;
+    return await new Promise((res) => {
+      const tx = db.transaction('kv', 'readonly');
+      const st = tx.objectStore('kv');
+      const r = st.get(k);
+      r.onsuccess = () => {
+        const it = r.result;
+        if (!it) return res(null);
+        if (Date.now() - it.t > explorerTtlMs) return res(null);
+        res(it.v);
+      };
+      r.onerror = () => res(null);
+    });
+  } catch {
+    return null;
+  }
+}
+async function idbSet(k, v) {
+  try {
+    const db = await openDb();
+    if (!db) return;
+    await new Promise((res) => {
+      const tx = db.transaction('kv', 'readwrite');
+      const st = tx.objectStore('kv');
+      st.put({ t: Date.now(), v }, k);
+      tx.oncomplete = () => res();
+      tx.onerror = () => res();
+    });
+  } catch {}
+}
+
+function stableKey(opts = {}) {
+  const fen = (opts.fen || '').trim();
+  const uciMoves = Array.isArray(opts.uciMoves) ? opts.uciMoves.join(' ') : '';
+  const speeds = Array.isArray(opts.speeds) ? [...opts.speeds].sort().join(',') : '';
+  const ratings = Array.isArray(opts.ratings) ? [...opts.ratings].sort((a, b) => a - b).join(',') : '';
+  const top = typeof opts.top === 'number' ? `top=${opts.top}` : '';
+  return `fen=${fen}|uci=${uciMoves}|sp=${speeds}|rt=${ratings}|${top}`;
+}
+
+const inflight = new Map();
+
+class TokenBucket {
+  constructor({ rate, per, burst }) {
+    this.rate = rate;
+    this.per = per;
+    this.capacity = burst ?? rate;
+    this.tokens = this.capacity;
+    this.last = Date.now();
+  }
+  _refill() {
+    const now = Date.now();
+    const elapsed = now - this.last;
+    const add = (elapsed / this.per) * this.rate;
+    if (add > 0) {
+      this.tokens = Math.min(this.capacity, this.tokens + add);
+      this.last = now;
+    }
+  }
+  async wait() {
+    this._refill();
+    if (this.tokens >= 1) {
+      this.tokens -= 1;
+      return;
+    }
+    const needed = 1 - this.tokens;
+    const ms = Math.ceil((needed / this.rate) * this.per);
+    await new Promise((r) => setTimeout(r, Math.max(ms, 50)));
+    return this.wait();
+  }
+}
+let bucket = new TokenBucket(rateLimitConfig);
+const queue = [];
+let running = false;
+async function runLoop() {
+  if (running) return;
+  running = true;
+  while (queue.length) {
+    const job = queue.shift();
+    if (!job) continue;
+    await bucket.wait();
+    await job();
+  }
+  running = false;
+}
+
+export async function explorerQuery(opts) {
+  const key = stableKey(opts);
+  const memo = memGet(key);
+  if (memo) return memo;
+  const pending = inflight.get(key);
+  if (pending) return pending;
+  const cached = await idbGet(key);
+  if (cached) {
+    memSet(key, cached);
+    return cached;
+  }
+  const p = new Promise((resolve, reject) => {
+    queue.push(async () => {
+      try {
+        const data = await fetchExplorer(opts);
+        memSet(key, data);
+        idbSet(key, data);
+        inflight.delete(key);
+        resolve(data);
+      } catch (err) {
+        inflight.delete(key);
+        reject(err);
+      }
+    });
+    runLoop();
+  });
+  inflight.set(key, p);
+  return p;
+}
+
+export function setExplorerClientOptions({ ttlMs, maxItems, rateLimit } = {}) {
+  let shouldResetBucket = false;
+  if (Number.isFinite(ttlMs) && ttlMs > 0) {
+    explorerTtlMs = ttlMs;
+  }
+  if (Number.isFinite(maxItems) && maxItems > 0) {
+    maxCacheItems = maxItems;
+  }
+  if (rateLimit && typeof rateLimit === 'object') {
+    rateLimitConfig = {
+      rate: Number.isFinite(rateLimit.rate) && rateLimit.rate > 0 ? rateLimit.rate : rateLimitConfig.rate,
+      per: Number.isFinite(rateLimit.per) && rateLimit.per > 0 ? rateLimit.per : rateLimitConfig.per,
+      burst: Number.isFinite(rateLimit.burst) && rateLimit.burst > 0 ? rateLimit.burst : rateLimitConfig.burst,
+    };
+    shouldResetBucket = true;
+  }
+  if (shouldResetBucket) {
+    bucket = new TokenBucket(rateLimitConfig);
+  }
+}
+
+export function getExplorerClientOptions() {
+  return {
+    ttlMs: explorerTtlMs,
+    maxItems: maxCacheItems,
+    rateLimit: { ...rateLimitConfig },
+  };
+}
+
+export function clearExplorerMemoryCache() {
+  mem.clear();
+  inflight.clear();
+}
+
+export { stableKey as buildExplorerCacheKey };

--- a/src/lichess/advisor.js
+++ b/src/lichess/advisor.js
@@ -1,6 +1,6 @@
 import { Chess } from 'chess.js';
 import { LICHESS_MIN_EXPECTED_SCORE } from "./constants.js";
-import { fetchExplorer } from "./explorer-service.js";
+import { explorerQuery } from "../explorer-client.js";
 import { fetchLichessMasters } from "./masters-service.js";
 import { pickLichessBucket } from "./rating.js";
 import { sanitizeSanSequence, loadPgnCompat, extractPliesFromPgn } from "./pgn.js";
@@ -38,7 +38,7 @@ export async function adviseFromLichess({
   const ratings = [pickLichessBucket(playerRating, { offset: ratingOffset })];
   const speeds = [speed];
 
-  const data = await fetchExplorer({ fen, uciMoves, speeds, ratings });
+  const data = await explorerQuery({ fen, uciMoves, speeds, ratings });
   const stm = sideToMove ?? (plies % 2 === 0 ? "white" : "black");
   const suggestions = scoreMoves(data, stm, {
     minExpectedScore: LICHESS_MIN_EXPECTED_SCORE,

--- a/src/lichess/http.js
+++ b/src/lichess/http.js
@@ -47,6 +47,7 @@ export async function fetchJson(
           rateErr.body = body;
           rateErr.url = url;
           rateErr.retryAfterMs = retryAfterMs;
+          rateErr.headers = response.headers;
           throw rateErr;
         }
 


### PR DESCRIPTION
## Summary
- introduce a reusable explorer client with memory/IndexedDB cache, in-flight deduplication, and token bucket rate limiting
- cache lichess advice responses, gate explorer usage in the legacy app, and add per-run explorer reuse plus smarter 429 handling
- expose explorer cache and gating controls in the UI and wire configuration into analysis workflows

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dfbbcc20948327abb491123a467ed0